### PR TITLE
Add help and info commands.

### DIFF
--- a/src/cogs/meta.py
+++ b/src/cogs/meta.py
@@ -17,3 +17,11 @@ class Meta (Cog):
   @command(name = "ses")
   async def ses(self, ctx):
     await ctx.send("fuck you evan")
+
+  @command(name = "help")
+  async def help(self, ctx):
+      await ctx.send("Muffinwoman Help Page\n---\n.help: This help info.\n.play [url]: Play media from URL and join voice.\n.leave: Stop playing and leave voice channel.\n.join: Force the bot to join your channel.\n.info: Show software, developer, and license info.\n---\nTip: there is a queue! Just run the .play command to add to it.")
+
+  @command(name = "info")
+  async def info(self, ctx):
+      await ctx.send("Muffinwoman is created by Cole Vohs. Read the code, create issues, and send patches at the repository: https://github.com/ColeW-Picaro/muffinwoman. Licensed under the GPLv3.")


### PR DESCRIPTION
Adds two commands to meta.py so that users can see all the commands listed.

.help:

```
Muffinwoman Help Page
---
.help: This help info.
.play [url]: Play media from URL and join voice.
.leave: Stop playing and leave voice channel.
.join: Force the bot to join your channel.
.info: Show software, developer, and license info.
---
Tip: there is a queue! Just run the .play command to add to it.
```

.info

```Muffinwoman is created by Cole Vohs. Read the code, create issues, and send patches at the repository: https://github.com/ColeW-Picaro/muffinwoman. Licensed under the GPLv3.```